### PR TITLE
Fix dtls stop failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ _build/
 examples/sample.iml
 gen_coap.iml
 rebar.lock
+.rebar3/

--- a/src/coap_server.erl
+++ b/src/coap_server.erl
@@ -60,13 +60,13 @@ start_dtls(Name, DtlsOpts) ->
 start_dtls(Name, DtlsPort, DtlsOpts) ->
     supervisor:start_child(?MODULE,
         {Name,
-            {coap_dtls_listen, start_link, [DtlsPort, DtlsOpts]},
+            {coap_dtls_listen, start_link, [Name, DtlsPort, DtlsOpts]},
             transient, 5000, worker, []}).
 
 stop_dtls(Name) ->
     supervisor:terminate_child(?MODULE, Name),
-    supervisor:delete_child(?MODULE, Name).
-
+    supervisor:delete_child(?MODULE, Name),
+    coap_dtls_listen:stop(Name).
 
 channel_sup(SupPid) -> child(SupPid, coap_channel_sup_sup).
 


### PR DESCRIPTION
In the previous verison (v0.2.2) , the `coap_server:stop_dtls/1` can not close DTLS Listen Socket.  It will casue the `emqx_coap`  plugin canot load again.

