### PR TITLE
fix(channel): fix bad_return_value crash if received bad datagram

### DIFF
--- a/src/coap_channel.erl
+++ b/src/coap_channel.erl
@@ -108,7 +108,6 @@ handle_cast({send_response, Message, Receiver}, State) ->
 handle_cast(shutdown, State) ->
     {stop, normal, State};
 handle_cast(Request, State) ->
-    io:fwrite("coap_channel unknown cast ~p~n", [Request]),
     {noreply, State}.
 
 transport_new_request(Message, Receiver, State=#state{tokens=Tokens}) ->
@@ -167,7 +166,6 @@ handle_info({ssl_closed, _Sock}, State) ->
     {stop, normal, State};
 
 handle_info(Info, State) ->
-    io:fwrite("unexpected massage ~p~n", [Info]),
     {noreply, State}.
 
 code_change(_OldVsn, State, _Extra) ->
@@ -200,8 +198,8 @@ handle_datagram(BinMessage= <<?VERSION:2, 0:1, _:1, TKL:4, _Code:8, MsgId:16, To
                 error ->
                     % token was not recognized
                     BinReset = coap_message_parser:encode(#coap_message{type=reset, id=MsgId}),
-                    io:fwrite("<- reset~n"),
-                    esockd_send(Socket, ChId, BinReset)
+                    esockd_send(Socket, ChId, BinReset),
+                    {stop, normal, State}
             end
     end;
 % incoming ACK(2) or RST(3) to a request or response

--- a/src/coap_channel.erl
+++ b/src/coap_channel.erl
@@ -107,7 +107,7 @@ handle_cast({send_response, Message, Receiver}, State) ->
     transport_response(Message, Receiver, State);
 handle_cast(shutdown, State) ->
     {stop, normal, State};
-handle_cast(Request, State) ->
+handle_cast(_Request, State) ->
     {noreply, State}.
 
 transport_new_request(Message, Receiver, State=#state{tokens=Tokens}) ->
@@ -165,7 +165,7 @@ handle_info({inet_reply, _Sock, ok}, State) ->
 handle_info({ssl_closed, _Sock}, State) ->
     {stop, normal, State};
 
-handle_info(Info, State) ->
+handle_info(_Info, State) ->
     {noreply, State}.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/src/gen_coap.appup.src
+++ b/src/gen_coap.appup.src
@@ -3,12 +3,14 @@
    [
     {<<"0\\.4\\.[0-1]*">>,
      [{load_module,coap_client,brutal_purge,soft_purge,[]},
+      {load_module,coap_channel,brutal_purge,soft_purge,[]},
       {load_module,core_link,brutal_purge,soft_purge,[]}]},
     {<<".*">>, []}
    ],
    [
     {<<"0\\.4\\.[0-1]*">>,
      [{load_module,coap_client,brutal_purge,soft_purge,[]},
+      {load_module,coap_channel,brutal_purge,soft_purge,[]},
       {load_module,core_link,brutal_purge,soft_purge,[]}]},
     {<<".*">>, []}
    ]


### PR DESCRIPTION
The previous code had a wrong path that would cause `coap_channel:handle_info` to return an `ok` instead of a legitimate gen_server return value.

i.e: when receiving a `Health udp check`.

```
(emqx@127.0.0.1)2> <- reset
2022-10-08T21:35:30.211836+08:00 [error] Generic server <0.1991.0> terminating. Reason: {bad_return_value,ok}. Last message: {datagram,<0.1974.0>,<<"Health udp check">>}. State: {state,{udp,<0.1974.0>,#Port<0.18>},{{127,0,0,1},53801},{dict,0,16,16,8,80,48,{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},{{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]}}},{dict,0,16,16,8,80,48,{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},{{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]}}},51110,<0.1992.0>,0}.
2022-10-08T21:35:30.212200+08:00 [error] crasher: initial call: coap_channel:init/1, pid: <0.1991.0>, registered_name: [], exit: {{bad_return_value,ok},[{gen_server,handle_common_reply,8,[{file,"gen_server.erl"},{line,815}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}, ancestors: [<0.1974.0>,esockd_sup,<0.1589.0>], message_queue_len: 0, messages: [], links: [<0.1974.0>,<0.1992.0>], dictionary: [{rand_seed,{#{jump => #Fun<rand.12.92093067>,max => 18446744073709551615,next => #Fun<rand.11.92093067>,type => exs1024},{[15129023680585256125,12050720523655856449,16266143676391674138,9970036770184485378,17913699774073282345,6040355794134570217,8497759018524124951,16833301762321495475,11609740410987461231,141355458198255140,10337877718380353604,8585323567002667231,1999512005623218063,10523648147256698408,2881530529578395078],[18398678993522735789]}}}], trap_exit: true, status: running, heap_size: 6772, stack_size: 29, reductions: 9036; neighbours:
2022-10-08T21:35:30.212683+08:00 [error] Generic server <0.1992.0> terminating. Reason: {bad_return_value,ok}. Last message: {'EXIT',<0.1991.0>,{bad_return_value,ok}}. State: {state,{<0.1992.0>,coap_responder_sup},one_for_one,{[],#{}},undefined,3,10,[],0,never,coap_responder_sup,[]}.
2022-10-08T21:35:30.212904+08:00 [error] crasher: initial call: supervisor:coap_responder_sup/1, pid: <0.1992.0>, registered_name: [], exit: {{bad_return_value,ok},[{gen_server,decode_msg,9,[{file,"gen_server.erl"},{line,481}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}, ancestors: [<0.1991.0>,<0.1974.0>,esockd_sup,<0.1589.0>], message_queue_len: 0, messages: [], links: [], dictionary: [], trap_exit: true, status: running, heap_size: 2586, stack_size: 29, reductions: 6890; neighbours:

```